### PR TITLE
Add option to log fine-tune checkpoints to wandb

### DIFF
--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -249,14 +249,8 @@
         "\n",
         "%cd /content/sample-generator/\n",
         "\n",
-        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --accum-batches $ACCUM_BATCHES --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR"
-      ],
-      "metadata": {
-        "id": "-Q0XrS0HEmch",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --accum-batches $ACCUM_BATCHES --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_models_to_wandb"
+      ]
     }
   ],
   "metadata": {

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -248,8 +248,7 @@
         "OUTPUT_DIR = f\"{OUTPUT_DIR}/{NAME}\".replace(f\" \", f\"\\ \")\n",
         "\n",
         "%cd /content/sample-generator/\n",
-        "\n",
-        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_models_to_wandb"
+        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --accum-batches $ACCUM_BATCHES --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_models_to_wandb"
       ]
     }
   ],

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -154,7 +154,8 @@
         "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
         "save_models_to_wandb = False #@param {type:\"boolean\"}\n",
         "if save_models_to_wandb == True:\n",
-        "    save_wandb = 'all'"
+        "    save_wandb = 'all'\n",
+        "    print('Saving model checkpoints in wandb')"
       ]
     },
     {

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -247,7 +247,7 @@
         "\n",
         "%cd /content/sample-generator/\n",
         "\n",
-        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save_wandb $save_models_to_wandb"
+        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_models_to_wandb"
       ]
     }
   ],

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -249,7 +249,7 @@
         "\n",
         "%cd /content/sample-generator/\n",
         "\n",
-        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --accum-batches $ACCUM_BATCHES --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_models_to_wandb"
+        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --accum-batches $ACCUM_BATCHES --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save-wandb $save_wandb"
       ]
     }
   ],

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -2,6 +2,13 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Harmonai-org/sample-generator/blob/main/Finetune_Dance_Diffusion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "HHcTRGvUmoME"
       },

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -142,15 +142,18 @@
         "        createPath(model_path)\n",
         "else:\n",
         "    model_path = f'{root_path}/models'\n",
-        "    createPath(model_path)"
+        "    createPath(model_path)\n",
+        "\n",
+        "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
+        "save_models_to_wandb = False #@param {type:\"boolean\"}"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "y9BS0ks1oEgP",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "y9BS0ks1oEgP"
       },
       "outputs": [],
       "source": [
@@ -161,28 +164,34 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# Train"
-      ],
       "metadata": {
         "id": "0xq2TJzIPTcJ"
-      }
+      },
+      "source": [
+        "# Train"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#@markdown Log in to [Weights & Biases](https://wandb.ai/) for run tracking\n",
-        "!wandb login"
-      ],
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "oxJFFEZ8CD8g"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#@markdown Log in to [Weights & Biases](https://wandb.ai/) for run tracking\n",
+        "!wandb login"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "-Q0XrS0HEmch"
+      },
+      "outputs": [],
       "source": [
         "#@markdown Name for the finetune project, used as the W&B project name, as well as the directory for the saved checkpoints\n",
         "NAME=\"dd-drums-finetune\" #@param {type:\"string\"}\n",
@@ -231,14 +240,8 @@
         "\n",
         "%cd /content/sample-generator/\n",
         "\n",
-        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR"
-      ],
-      "metadata": {
-        "id": "-Q0XrS0HEmch",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+        "!python3 /content/sample-generator/train_uncond.py --ckpt-path $CKPT_PATH --name $NAME --training-dir $TRAINING_DIR --sample-size $SAMPLE_SIZE --sample-rate $SAMPLE_RATE --batch-size $BATCH_SIZE --demo-every $DEMO_EVERY --demo-steps 100 --checkpoint-every $CHECKPOINT_EVERY --num-workers 2 $random_crop_str --save-path $OUTPUT_DIR --save_wandb $save_models_to_wandb"
+      ]
     }
   ],
   "metadata": {

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -152,7 +152,9 @@
         "    createPath(model_path)\n",
         "\n",
         "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
-        "save_models_to_wandb = False #@param {type:\"boolean\"}"
+        "save_models_to_wandb = False #@param {type:\"boolean\"}\n",
+        "if save_models_to_wandb == True:\n",
+        "    save_wandb = 'all'"
       ]
     },
     {
@@ -262,11 +264,18 @@
     },
     "gpuClass": "standard",
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "Python 3.8.8 ('ml')",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "version": "3.8.8"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "9ce29cb5aeaaebb09d381145ff1103741c9816dbccbfcb1b857cd83265b8bd84"
+      }
     }
   },
   "nbformat": 4,

--- a/defaults.ini
+++ b/defaults.ini
@@ -65,4 +65,4 @@ save_path = ''
 start_method = 'spawn'
 
 # Whether to save the model checkpoints to Weights & Biases
-save_wandb = False
+save_wandb = ''

--- a/defaults.ini
+++ b/defaults.ini
@@ -65,4 +65,4 @@ save_path = ''
 start_method = 'spawn'
 
 # Whether to save the model checkpoints to Weights & Biases
-save_wandb = ''
+save_wandb = 'none'

--- a/defaults.ini
+++ b/defaults.ini
@@ -63,3 +63,6 @@ save_path = ''
 
 #the multiprocessing start method ['fork', 'forkserver', 'spawn']
 start_method = 'spawn'
+
+# Whether to save the model checkpoints to Weights & Biases
+save_wandb = False

--- a/train_uncond.py
+++ b/train_uncond.py
@@ -198,7 +198,7 @@ def main():
     train_set = SampleDataset([args.training_dir], args)
     train_dl = data.DataLoader(train_set, args.batch_size, shuffle=True,
                                num_workers=args.num_workers, persistent_workers=True, pin_memory=True)
-    wandb_logger = pl.loggers.WandbLogger(project=args.name)
+    wandb_logger = pl.loggers.WandbLogger(project=args.name, log_model=args.save_wandb)
 
     exc_callback = ExceptionCallback()
     ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1, dirpath=save_path)
@@ -210,7 +210,7 @@ def main():
     push_wandb_config(wandb_logger, args)
 
     diffusion_trainer = pl.Trainer(
-        gpus=args.num_gpus,
+        devices=args.num_gpus,
         accelerator="gpu",
         # num_nodes = args.num_nodes,
         # strategy='ddp',

--- a/train_uncond.py
+++ b/train_uncond.py
@@ -198,7 +198,7 @@ def main():
     train_set = SampleDataset([args.training_dir], args)
     train_dl = data.DataLoader(train_set, args.batch_size, shuffle=True,
                                num_workers=args.num_workers, persistent_workers=True, pin_memory=True)
-    wandb_logger = pl.loggers.WandbLogger(project=args.name, log_model='all' if args.save_wandb else None)
+    wandb_logger = pl.loggers.WandbLogger(project=args.name, log_model='all' if args.save_wandb=='all' else None)
 
     exc_callback = ExceptionCallback()
     ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1, dirpath=save_path)

--- a/train_uncond.py
+++ b/train_uncond.py
@@ -198,7 +198,7 @@ def main():
     train_set = SampleDataset([args.training_dir], args)
     train_dl = data.DataLoader(train_set, args.batch_size, shuffle=True,
                                num_workers=args.num_workers, persistent_workers=True, pin_memory=True)
-    wandb_logger = pl.loggers.WandbLogger(project=args.name, log_model=args.save_wandb)
+    wandb_logger = pl.loggers.WandbLogger(project=args.name, log_model='all' if args.save_wandb else None)
 
     exc_callback = ExceptionCallback()
     ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1, dirpath=save_path)


### PR DESCRIPTION
This PR:

- Adds optional logging of checkpoints to Weights & Biases, with the same frequency as the google drive frequency
- Adds an open-in-colab badge to the Finetuning notebook
- Fixes an PL warning to use `devices=n_gpus` instead of `gpus=n_gpus`

Tested:
- save_models_to_google_drive = True | save_wandb = True
- save_models_to_google_drive = False | save_wandb = True
- - save_models_to_google_drive = False | save_wandb = False

**Try it yourself**
[Colab using the `add_wandb_artifacts_checkpointing` branch](https://colab.research.google.com/drive/1NgKCbw8xE1P-7e_4Y1x55Ukgv59auriN?usp=sharing)

**Examples**

- Example wandb run: https://wandb.ai/wandb_gen/dd-drums-finetune/runs/98yvisk4
- [Weights & Biases Artifacts page](https://wandb.ai/wandb_gen/dd-drums-finetune/artifacts) from above project with the checkpoint
- Screenshot of checkpoint saved in Weights & Biases alongside all the training  metadata at that point:

<img width="1381" alt="Screenshot 2022-10-05 at 16 15 01" src="https://user-images.githubusercontent.com/20516801/194098300-debdf471-dee2-40b8-b999-2dfcd3d0f77b.png">

- Screenshot of the optional `wandb` selector:
<img width="891" alt="Screenshot 2022-10-05 at 16 23 09" src="https://user-images.githubusercontent.com/20516801/194098872-9d93a38e-f032-47b8-9045-ee0e05fdb1bc.png">