### PR TITLE
Fix finetune notebook error: --name: expected one argument

### DIFF
--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -264,7 +264,7 @@
         "                                                          --demo-every $DEMO_EVERY \\\n",
         "                                                          --checkpoint-every $CHECKPOINT_EVERY \\\n",
         "                                                          --num-workers 2 \\\n",
-        "                                                          $save_wandb_str \
+        "                                                          $save_wandb_str \\\n",
         "                                                          --num-gpus 1 \\\n",
         "                                                          $random_crop_str \\\n",
         "                                                          --save-path $OUTPUT_DIR"

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -155,9 +155,8 @@
         "\n",
         "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
         "save_models_to_wandb = False #@param {type:\"boolean\"}\n",
-        "save_wandb = 'none'\n",
+        "save_wandb_str = 'save-wandb all' if save_models_to_wandb else ''\n",
         "if save_models_to_wandb == True:\n",
-        "    save_wandb = 'all'\n",
         "    print('Saving model checkpoints in wandb')"
       ]
     },
@@ -265,7 +264,7 @@
         "                                                          --demo-every $DEMO_EVERY \\\n",
         "                                                          --checkpoint-every $CHECKPOINT_EVERY \\\n",
         "                                                          --num-workers 2 \\\n",
-        "                                                          --save-wandb $save_wandb",
+        "                                                          $save_wandb_str \
         "                                                          --num-gpus 1 \\\n",
         "                                                          $random_crop_str \\\n",
         "                                                          --save-path $OUTPUT_DIR"

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -155,7 +155,7 @@
         "\n",
         "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
         "save_models_to_wandb = False #@param {type:\"boolean\"}\n",
-        "save_wandb_str = 'save-wandb all' if save_models_to_wandb else ''\n",
+        "save_wandb_str = '--save-wandb all' if save_models_to_wandb else ''\n",
         "if save_models_to_wandb == True:\n",
         "    print('Saving model checkpoints in wandb')"
       ]

--- a/Finetune_Dance_Diffusion.ipynb
+++ b/Finetune_Dance_Diffusion.ipynb
@@ -155,6 +155,7 @@
         "\n",
         "#@markdown Click here if you'd like to save the diffusion model checkpoint file to your [Weights & Biases](www.wandb.ai/site) account:\n",
         "save_models_to_wandb = False #@param {type:\"boolean\"}\n",
+        "save_wandb = 'none'\n",
         "if save_models_to_wandb == True:\n",
         "    save_wandb = 'all'\n",
         "    print('Saving model checkpoints in wandb')"


### PR DESCRIPTION
This PR fixes the error when the finetune notebook runs the training script: "--name: expected one argument"

If save_models_to_wandb is unchecked then it doesn't pass the save-wandb param to the training script and it works like before using the default value. If it is checked then '--save-wandb all' is passed