### PR TITLE
 fix v-ddim regeneration in inference notebook

### DIFF
--- a/Dance_Diffusion.ipynb
+++ b/Dance_Diffusion.ipynb
@@ -830,7 +830,7 @@
         "    return sampling.iplms_sample(model_fn, noised, step_list.flip(0)[:-1], {})\n",
         "\n",
         "  if sampler_type == \"v-ddim\":\n",
-        "    return sampling.sample(model_fn, noise, step_list, eta, {})\n",
+        "    return sampling.sample(model_fn, noise, step_list.flip(0)[:-1], eta, {})\n",
         "\n",
         "  elif sampler_type == \"k-heun\":\n",
         "    return K.sampling.sample_heun(denoiser, noised, sigmas, disable=False)\n",


### PR DESCRIPTION
Regeneration using the v-ddim sampler in the inference notebook isn’t working… To fix it I just copied the code used for the v-iplms sampler, which uses “stepList.flip(0)[:-1]” instead of “stepList”. It’s a little fix I made to my copy of the notebook several days ago that seems to be working well.